### PR TITLE
Ensure that `pieces` is strings *before* using `startswith`.

### DIFF
--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -442,6 +442,11 @@ class _FeedParserMixin(
 
         element, expectingText, pieces = self.elementstack.pop()
 
+        # Ensure each piece is a str for Python 3
+        for (i, v) in enumerate(pieces):
+            if isinstance(v, bytes_):
+                pieces[i] = v.decode('utf-8')
+
         if self.version == 'atom10' and self.contentparams.get('type', 'text') == 'application/xhtml+xml':
             # remove enclosing child element, but only if it is a <div> and
             # only if all the remaining content is nested underneath it.
@@ -462,11 +467,6 @@ class _FeedParserMixin(
                         depth += 1
                 else:
                     pieces = pieces[1:-1]
-
-        # Ensure each piece is a str for Python 3
-        for (i, v) in enumerate(pieces):
-            if isinstance(v, bytes_):
-                pieces[i] = v.decode('utf-8')
 
         output = ''.join(pieces)
         if stripWhitespace:


### PR DESCRIPTION
Conversion of `pieces` to strings rather than bytes happened too late for the `div` removing loop. Move the conversion earlier.